### PR TITLE
Suppress stroke key down count if zero_last_stroke_length is true

### DIFF
--- a/plover_engine_server/manager.py
+++ b/plover_engine_server/manager.py
@@ -94,6 +94,7 @@ class EngineServerManager():
 
             if data.get('zero_last_stroke_length'):
                 self._engine._machine._last_stroke_key_down_count = 0
+                self._engine._machine._stroke_key_down_count = 0
 
             import traceback
 


### PR DESCRIPTION
* plover_engine_server/manager.py: Suppress current stroke down count
  as well, in case it was used to trigger the websocket call.

Closes: #3