### PR TITLE
Add rtfcre to stroked broadcast message

### DIFF
--- a/plover_engine_server/manager.py
+++ b/plover_engine_server/manager.py
@@ -169,7 +169,7 @@ class EngineServerManager():
 
         stroke_json = jsonpickle.encode(stroke, unpicklable=False)
 
-        data = {'stroked': json.loads(stroke_json)}
+        data = {'stroked': json.loads(stroke_json), 'rtfcre': stroke.rtfcre}
         self._server.queue_message(data)
 
     def _on_translated(self, old: List[_Action], new: List[_Action]):


### PR DESCRIPTION
* plover_engine_server/manager.py (EngineServerManager._on_stroked): Add rtfcre to stroked broadcast message.